### PR TITLE
Fix error log caller location

### DIFF
--- a/internal/telegram/error_logger.go
+++ b/internal/telegram/error_logger.go
@@ -3,6 +3,7 @@ package telegram
 import (
 	"fmt"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -129,6 +130,14 @@ func (el *ErrorLogger) formatErrorMessage(err error, context string, userInfo ..
 
 	// Add stack trace for debugging (limited to 3 most recent calls)
 	if pc, file, line, ok := runtime.Caller(2); ok {
+		// if the caller is within this file, step one level further up the stack
+		if strings.Contains(file, "error_logger.go") {
+			if pc2, file2, line2, ok2 := runtime.Caller(3); ok2 {
+				pc = pc2
+				file = file2
+				line = line2
+			}
+		}
 		funcName := runtime.FuncForPC(pc).Name()
 		msg += fmt.Sprintf("\n*Location:* `%s:%d` in `%s`", el.escapeMarkdownV2(file), line, el.escapeMarkdownV2(funcName))
 	}
@@ -272,17 +281,66 @@ func (el *ErrorLogger) getUserStrV2(user *tb.User) string {
 	return fmt.Sprintf("%s %s", el.escapeMarkdownV2(user.FirstName), el.escapeMarkdownV2(user.LastName))
 }
 
-// LogPaymentError logs payment-related errors with detailed information
-func (el *ErrorLogger) LogPaymentError(err error, paymentDetails, invoice string, user *tb.User) {
-	context := fmt.Sprintf("Payment Failure - %s", paymentDetails)
-
-	userInfo := fmt.Sprintf("> *User:* %s \\(ID: %d\\)", el.getUserStrV2(user), user.ID)
-	if len(invoice) > 50 {
-		invoice = invoice[:50] + "..."
+// formatSats returns a comma separated representation of satoshi amounts
+func formatSats(amount int64) string {
+	s := strconv.FormatInt(amount, 10)
+	if len(s) <= 3 {
+		return s
 	}
-	paymentInfo := fmt.Sprintf("> *Invoice:* `%s`\n> *Payment Error:* `%s`", el.escapeMarkdownV2(invoice), el.escapeMarkdownV2(err.Error()))
+	var b strings.Builder
+	pre := len(s) % 3
+	if pre > 0 {
+		b.WriteString(s[:pre])
+		if len(s) > pre {
+			b.WriteRune(',')
+		}
+	}
+	for i := pre; i < len(s); i += 3 {
+		if i > 0 && i != pre {
+			b.WriteRune(',')
+		}
+		b.WriteString(s[i : i+3])
+	}
+	return b.String()
+}
 
-	el.LogError(err, context, user, userInfo, paymentInfo)
+// LogPaymentError logs payment-related errors with detailed information
+func (el *ErrorLogger) LogPaymentError(err error, amount int64, memo, invoice string, user *tb.User) {
+	if !el.enabled || err == nil {
+		return
+	}
+
+	if len(invoice) > 80 {
+		invoice = invoice[:80] + "..."
+	}
+	if memo == "" {
+		memo = "None"
+	}
+
+	timestamp := time.Now().Format("2006-01-02 15:04:05 UTC")
+
+	msg := fmt.Sprintf("🚫 Payment Error for %s (ID: %d)\n\n", el.getUserStrV2(user), user.ID)
+	msg += fmt.Sprintf("💰 Amount: %s sats\n", el.escapeMarkdownV2(formatSats(amount)))
+	msg += fmt.Sprintf("📝 Memo: %s\n", el.escapeMarkdownV2(memo))
+	msg += fmt.Sprintf("📄 Invoice: %s\n", el.escapeMarkdownV2(invoice))
+	msg += fmt.Sprintf("❗ Error: %s\n\n", el.escapeMarkdownV2(err.Error()))
+
+	if _, file, line, ok := runtime.Caller(1); ok {
+		if strings.Contains(file, "error_logger.go") {
+			if _, file2, line2, ok2 := runtime.Caller(2); ok2 {
+				file = file2
+				line = line2
+			}
+		}
+		if idx := strings.Index(file, "/internal/"); idx > -1 {
+			file = file[idx:]
+		}
+		msg += fmt.Sprintf("📍 Logged at:\n%s:%d\n(from github.com/LightningTipBot/LightningTipBot)", el.escapeMarkdownV2(file), line)
+	}
+
+	msg += fmt.Sprintf("\n🕒 Time: %s", el.escapeMarkdownV2(timestamp))
+
+	go el.sendToTelegram(msg)
 }
 
 // LogTransactionError logs transaction-related errors with sender/receiver info

--- a/internal/telegram/groups.go
+++ b/internal/telegram/groups.go
@@ -307,7 +307,7 @@ func (bot *TipBot) groupConfirmPayButtonHandler(ctx intercept.Context) (intercep
 			bot.tryEditMessage(c, fmt.Sprintf(i18n.Translate(ticketEvent.LanguageCode, "invoicePaymentFailedMessage"), err.Error()), &tb.ReplyMarkup{})
 		}
 		if bot.ErrorLogger != nil {
-			bot.ErrorLogger.LogPaymentError(err, "Join Ticket Payment", ticketEvent.Invoice.PaymentHash, user.Telegram)
+			bot.ErrorLogger.LogPaymentError(err, ticketEvent.Group.Ticket.Price, "Join Ticket Payment", ticketEvent.Invoice.PaymentRequest, user.Telegram)
 		}
 		log.Errorln(errmsg)
 		return ctx, err

--- a/internal/telegram/pay.go
+++ b/internal/telegram/pay.go
@@ -216,8 +216,7 @@ func (bot *TipBot) confirmPayHandler(ctx intercept.Context) (intercept.Context, 
 
 		// Enhanced error logging with detailed payment information
 		if bot.ErrorLogger != nil {
-			paymentDetails := fmt.Sprintf("Amount: %d sat, Memo: %s", payData.Amount, payData.Memo)
-			bot.ErrorLogger.LogPaymentError(err, paymentDetails, payData.Invoice, user.Telegram)
+			bot.ErrorLogger.LogPaymentError(err, payData.Amount, payData.Memo, payData.Invoice, user.Telegram)
 		}
 
 		err = fmt.Errorf(i18n.Translate(payData.LanguageCode, "invoiceUndefinedErrorMessage"))


### PR DESCRIPTION
### **User description**
## Summary
- correctly attribute error logging location to caller outside error_logger
- improve payment error formatting

## Testing
- `go test ./...` *(fails: module downloads blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685ea2ff1418832ca4ddafbee715a18b


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix error log caller location attribution

- Improve payment error message formatting with emojis

- Add comma-separated satoshi amount formatting

- Simplify payment error logging function signature


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>error_logger.go</strong><dd><code>Enhanced error logging with caller fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/telegram/error_logger.go

<li>Fix caller location detection to skip error_logger.go frames<br> <li> Add <code>formatSats</code> function for comma-separated number formatting<br> <li> Rewrite <code>LogPaymentError</code> with enhanced formatting and emojis<br> <li> Simplify function signature to accept individual parameters


</details>


  </td>
  <td><a href="https://github.com/CeyLabs/BitcoinDeepaBot/pull/18/files#diff-1d7990c9d23d5dff47330e9c825df9e2194e531c94f998763fc6f1802258f382">+65/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>groups.go</strong><dd><code>Update payment error logging call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/telegram/groups.go

<li>Update <code>LogPaymentError</code> call to use new function signature<br> <li> Pass individual parameters instead of formatted string


</details>


  </td>
  <td><a href="https://github.com/CeyLabs/BitcoinDeepaBot/pull/18/files#diff-0ed8de58325966464c850442bb9df5e96394fa60b017a933b3c2f7ceb46fabcd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pay.go</strong><dd><code>Update payment error logging call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/telegram/pay.go

<li>Update <code>LogPaymentError</code> call to use new function signature<br> <li> Remove manual payment details formatting


</details>


  </td>
  <td><a href="https://github.com/CeyLabs/BitcoinDeepaBot/pull/18/files#diff-9bc2d9a6516f5c25284351bbad93c5710a3872ab9891e9b9f8e5b4a4fcef6758">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved readability of payment error logs by formatting satoshi amounts with commas.
  * Error logs now include clearer details such as formatted amount, memo, truncated invoice, error message, timestamp, and enhanced caller location.

* **Refactor**
  * Updated error logging to accept explicit payment details (amount, memo, invoice) instead of a single formatted string for better clarity in logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->