### PR TITLE
Improve number formatting

### DIFF
--- a/internal/telegram/api_approval.go
+++ b/internal/telegram/api_approval.go
@@ -10,6 +10,7 @@ import (
 	"github.com/LightningTipBot/LightningTipBot/internal/storage"
 	"github.com/LightningTipBot/LightningTipBot/internal/str"
 	"github.com/LightningTipBot/LightningTipBot/internal/telegram/intercept"
+	"github.com/LightningTipBot/LightningTipBot/internal/utils"
 	log "github.com/sirupsen/logrus"
 	tb "gopkg.in/lightningtipbot/telebot.v3"
 )
@@ -78,7 +79,7 @@ func (bot *TipBot) approveAPITransactionHandler(ctx intercept.Context) (intercep
 
 	if balance < approvalData.Amount {
 		log.Warnf("[approveAPITransactionHandler] Insufficient balance: %d < %d", balance, approvalData.Amount)
-		bot.tryEditMessage(ctx.Callback().Message, fmt.Sprintf("❌ Insufficient balance: %d sat available, %d sat required", balance, approvalData.Amount), &tb.ReplyMarkup{})
+		bot.tryEditMessage(ctx.Callback().Message, fmt.Sprintf("❌ Insufficient balance: %d sat available, %d sat required", utils.CommaInt(balance), utils.CommaInt(approvalData.Amount)), &tb.ReplyMarkup{})
 		return ctx, errors.Create(errors.UnknownError)
 	}
 
@@ -110,7 +111,7 @@ func (bot *TipBot) approveAPITransactionHandler(ctx intercept.Context) (intercep
 
 	// Notify recipient (same format as API send)
 	fromUserStrMd := GetUserStrMd(from.Telegram)
-	notificationMsg := fmt.Sprintf("💰 You received %d sat from %s via Automated API", approvalData.Amount, fromUserStrMd)
+	notificationMsg := fmt.Sprintf("💰 You received %d sat from %s via Automated API", utils.CommaInt(approvalData.Amount), fromUserStrMd)
 	if approvalData.Memo != "" {
 		notificationMsg += fmt.Sprintf("\n✉️ Memo: %s", str.MarkdownEscape(approvalData.Memo))
 	}
@@ -119,14 +120,14 @@ func (bot *TipBot) approveAPITransactionHandler(ctx intercept.Context) (intercep
 	// Update approval message to show success
 	if ctx.Callback().Message.Private() {
 		bot.tryDeleteMessage(ctx.Callback().Message)
-		successMsg := fmt.Sprintf("✅ Payment approved and sent successfully!\n\n💸 Amount: %d sat\n👤 To: @%s", approvalData.Amount, approvalData.ToUsername)
+		successMsg := fmt.Sprintf("✅ Payment approved and sent successfully!\n\n💸 Amount: %d sat\n👤 To: @%s", utils.CommaInt(approvalData.Amount), approvalData.ToUsername)
 		if approvalData.Memo != "" {
 			successMsg += fmt.Sprintf("\n✉️ Memo: %s", str.MarkdownEscape(approvalData.Memo))
 		}
 		bot.trySendMessage(ctx.Callback().Sender, successMsg)
 	} else {
 		toUserStrMd := GetUserStrMd(toUser.Telegram)
-		bot.tryEditMessage(ctx.Callback().Message, fmt.Sprintf("✅ API payment approved and sent!\n\n💸 %d sat → %s", approvalData.Amount, toUserStrMd), &tb.ReplyMarkup{})
+		bot.tryEditMessage(ctx.Callback().Message, fmt.Sprintf("✅ API payment approved and sent!\n\n💸 %d sat → %s", utils.CommaInt(approvalData.Amount), toUserStrMd), &tb.ReplyMarkup{})
 	}
 
 	return ctx, nil
@@ -167,14 +168,14 @@ func (bot *TipBot) cancelAPITransactionHandler(ctx intercept.Context) (intercept
 func CreateAPIApprovalRequest(bot *TipBot, fromUser *lnbits.User, toUsername string, amount int64, memo string, transactionID string, clientIP string) error {
 	// Create confirmation text (same format as /send command)
 	toUserStrMention := fmt.Sprintf("@%s", toUsername)
-	confirmText := fmt.Sprintf("Do you want to pay to %s?\n\n💸 Amount: %d sat", toUserStrMention, amount)
+	confirmText := fmt.Sprintf("Do you want to pay to %s?\n\n💸 Amount: %d sat", toUserStrMention, utils.CommaInt(amount))
 	if memo != "" {
 		confirmText += fmt.Sprintf("\n✉️ %s", str.MarkdownEscape(memo))
 	}
 
 	// Add approval context
 	confirmText += "\n\n🔔 *Admin Approval Required*\n"
-	confirmText += fmt.Sprintf("This transaction requires approval because the amount (%d sat) exceeds the threshold.", amount)
+	confirmText += fmt.Sprintf("This transaction requires approval because the amount (%d sat) exceeds the threshold.", utils.CommaInt(amount))
 
 	// Create unique ID for this approval request (same pattern as send command)
 	id := fmt.Sprintf("api-%d-%d-%s", fromUser.Telegram.ID, amount, RandStringRunes(5))

--- a/internal/telegram/balance.go
+++ b/internal/telegram/balance.go
@@ -1,16 +1,16 @@
 package telegram
 
 import (
-        "fmt"
+	"fmt"
 
-        "github.com/LightningTipBot/LightningTipBot/internal/errors"
-        "github.com/LightningTipBot/LightningTipBot/internal/telegram/intercept"
-        thirdparty "github.com/LightningTipBot/LightningTipBot/internal/thirdparty"
-        "github.com/LightningTipBot/LightningTipBot/internal/utils"
+	"github.com/LightningTipBot/LightningTipBot/internal/errors"
+	"github.com/LightningTipBot/LightningTipBot/internal/telegram/intercept"
+	thirdparty "github.com/LightningTipBot/LightningTipBot/internal/thirdparty"
+	"github.com/LightningTipBot/LightningTipBot/internal/utils"
 
-        log "github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
-        tb "gopkg.in/lightningtipbot/telebot.v3"
+	tb "gopkg.in/lightningtipbot/telebot.v3"
 )
 
 func (bot *TipBot) balanceHandler(ctx intercept.Context) (intercept.Context, error) {
@@ -50,9 +50,9 @@ func (bot *TipBot) balanceHandler(ctx intercept.Context) (intercept.Context, err
 		log.Infof("[/balance] error fetching price from coingecko\n")
 	}
 
-        USDValue := USDPerSat * float64(balance)
-        LKRValue := LKRPerSat * float64(balance)
+	USDValue := USDPerSat * float64(balance)
+	LKRValue := LKRPerSat * float64(balance)
 
-        bot.trySendMessage(ctx.Sender(), fmt.Sprintf(Translate(ctx, "balanceMessage"), balance, utils.FormatFloatWithCommas(USDValue), utils.FormatFloatWithCommas(LKRValue)))
-        return ctx, nil
+	bot.trySendMessage(ctx.Sender(), fmt.Sprintf(Translate(ctx, "balanceMessage"), utils.CommaInt(int64(balance)), utils.FormatFloatWithCommas(USDValue), utils.FormatFloatWithCommas(LKRValue)))
+	return ctx, nil
 }

--- a/internal/telegram/groups.go
+++ b/internal/telegram/groups.go
@@ -19,6 +19,7 @@ import (
 	"github.com/LightningTipBot/LightningTipBot/internal/runtime/mutex"
 	"github.com/LightningTipBot/LightningTipBot/internal/storage"
 	"github.com/LightningTipBot/LightningTipBot/internal/str"
+	"github.com/LightningTipBot/LightningTipBot/internal/utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/skip2/go-qrcode"
 	tb "gopkg.in/lightningtipbot/telebot.v3"
@@ -258,7 +259,7 @@ func (bot *TipBot) getSendPayButton(ctx intercept.Context, ticket TicketEvent) (
 		ticketPayConfirmationMenu.Row(
 			btnPayTicket),
 	)
-	confirmText := fmt.Sprintf(Translate(ctx, "confirmPayInvoiceMessage"), ticket.Group.Ticket.Price)
+	confirmText := fmt.Sprintf(Translate(ctx, "confirmPayInvoiceMessage"), utils.CommaInt(int64(ticket.Group.Ticket.Price)))
 	// if len(ticket.Group.Ticket.Memo) > 0 {
 	// 	confirmText = confirmText + fmt.Sprintf(Translate(ctx, "confirmPayAppendMemo"), str.MarkdownEscape(ticket.Group.Ticket.Memo))
 	// }

--- a/internal/telegram/inline_receive.go
+++ b/internal/telegram/inline_receive.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/LightningTipBot/LightningTipBot/internal/runtime/mutex"
 	"github.com/LightningTipBot/LightningTipBot/internal/storage"
+	"github.com/LightningTipBot/LightningTipBot/internal/utils"
 
 	"github.com/eko/gocache/store"
 	"github.com/skip2/go-qrcode"
@@ -101,7 +102,7 @@ func (bot TipBot) handleInlineReceiveQuery(ctx intercept.Context) (intercept.Con
 	}
 	results := make(tb.Results, len(urls)) // []tb.Result
 	for i, url := range urls {
-		inlineMessage := fmt.Sprintf(Translate(ctx, "inlineReceiveMessage"), toUserStr, amount)
+		inlineMessage := fmt.Sprintf(Translate(ctx, "inlineReceiveMessage"), toUserStr, utils.CommaInt(int64(amount)))
 
 		// modify message if payment is to specific user
 		if from_SpecificUser {
@@ -114,8 +115,8 @@ func (bot TipBot) handleInlineReceiveQuery(ctx intercept.Context) (intercept.Con
 		result := &tb.ArticleResult{
 			// URL:         url,
 			Text:        inlineMessage,
-			Title:       fmt.Sprintf(TranslateUser(ctx, "inlineResultReceiveTitle"), amount),
-			Description: fmt.Sprintf(TranslateUser(ctx, "inlineResultReceiveDescription"), amount),
+			Title:       fmt.Sprintf(TranslateUser(ctx, "inlineResultReceiveTitle"), utils.CommaInt(int64(amount))),
+			Description: fmt.Sprintf(TranslateUser(ctx, "inlineResultReceiveDescription"), utils.CommaInt(int64(amount))),
 			// required for photos
 			ThumbURL: url,
 		}
@@ -337,8 +338,8 @@ func (bot *TipBot) finishInlineReceiveHandler(ctx context.Context, c *tb.Callbac
 
 	bot.tryEditMessage(inlineReceive.Message, inlineReceive.MessageText, &tb.ReplyMarkup{})
 	// notify users
-	bot.trySendMessage(to.Telegram, fmt.Sprintf(i18n.Translate(to.Telegram.LanguageCode, "sendReceivedMessage"), fromUserStrMd, inlineReceive.Amount))
-	bot.trySendMessage(from.Telegram, fmt.Sprintf(i18n.Translate(from.Telegram.LanguageCode, "sendSentMessage"), inlineReceive.Amount, toUserStrMd))
+	bot.trySendMessage(to.Telegram, fmt.Sprintf(i18n.Translate(to.Telegram.LanguageCode, "sendReceivedMessage"), fromUserStrMd, utils.CommaInt(int64(inlineReceive.Amount))))
+	bot.trySendMessage(from.Telegram, fmt.Sprintf(i18n.Translate(from.Telegram.LanguageCode, "sendSentMessage"), utils.CommaInt(int64(inlineReceive.Amount)), toUserStrMd))
 	if err != nil {
 		errmsg := fmt.Errorf("[acceptInlineReceiveHandler] Error: Receive message to %s: %s", toUserStr, err)
 		log.Warnln(errmsg)

--- a/internal/telegram/inline_send.go
+++ b/internal/telegram/inline_send.go
@@ -17,6 +17,7 @@ import (
 	"github.com/LightningTipBot/LightningTipBot/internal/i18n"
 
 	"github.com/LightningTipBot/LightningTipBot/internal/lnbits"
+	"github.com/LightningTipBot/LightningTipBot/internal/utils"
 
 	log "github.com/sirupsen/logrus"
 	tb "gopkg.in/lightningtipbot/telebot.v3"
@@ -112,7 +113,7 @@ func (bot TipBot) handleInlineSendQuery(ctx intercept.Context) (intercept.Contex
 	}
 	results := make(tb.Results, len(urls)) // []tb.Result
 	for i, url := range urls {
-		inlineMessage := fmt.Sprintf(Translate(ctx, "inlineSendMessage"), fromUserStr, amount)
+		inlineMessage := fmt.Sprintf(Translate(ctx, "inlineSendMessage"), fromUserStr, utils.CommaInt(int64(amount)))
 
 		// modify message if payment is to specific user
 		if to_SpecificUser {
@@ -125,8 +126,8 @@ func (bot TipBot) handleInlineSendQuery(ctx intercept.Context) (intercept.Contex
 		result := &tb.ArticleResult{
 			// URL:         url,
 			Text:        inlineMessage,
-			Title:       fmt.Sprintf(TranslateUser(ctx, "inlineResultSendTitle"), amount),
-			Description: fmt.Sprintf(TranslateUser(ctx, "inlineResultSendDescription"), amount),
+			Title:       fmt.Sprintf(TranslateUser(ctx, "inlineResultSendTitle"), utils.CommaInt(int64(amount))),
+			Description: fmt.Sprintf(TranslateUser(ctx, "inlineResultSendDescription"), utils.CommaInt(int64(amount))),
 			// required for photos
 			ThumbURL: url,
 		}
@@ -237,7 +238,7 @@ func (bot *TipBot) acceptInlineSendHandler(ctx intercept.Context) (intercept.Con
 
 	log.Infof("[💸 sendInline] Send from %s to %s (%d sat).", fromUserStr, toUserStr, amount)
 
-	inlineSend.Message = fmt.Sprintf("%s", fmt.Sprintf(i18n.Translate(inlineSend.LanguageCode, "inlineSendUpdateMessageAccept"), amount, fromUserStrMd, toUserStrMd))
+	inlineSend.Message = fmt.Sprintf("%s", fmt.Sprintf(i18n.Translate(inlineSend.LanguageCode, "inlineSendUpdateMessageAccept"), utils.CommaInt(int64(amount)), fromUserStrMd, toUserStrMd))
 	memo := inlineSend.Memo
 	if len(memo) > 0 {
 		inlineSend.Message = inlineSend.Message + fmt.Sprintf(i18n.Translate(inlineSend.LanguageCode, "inlineSendAppendMemo"), memo)
@@ -247,8 +248,8 @@ func (bot *TipBot) acceptInlineSendHandler(ctx intercept.Context) (intercept.Con
 	}
 	bot.tryEditMessage(c, inlineSend.Message, &tb.ReplyMarkup{})
 	// notify users
-	bot.trySendMessage(to.Telegram, fmt.Sprintf(i18n.Translate(to.Telegram.LanguageCode, "sendReceivedMessage"), fromUserStrMd, amount))
-	bot.trySendMessage(fromUser.Telegram, fmt.Sprintf(i18n.Translate(fromUser.Telegram.LanguageCode, "sendSentMessage"), amount, toUserStrMd))
+	bot.trySendMessage(to.Telegram, fmt.Sprintf(i18n.Translate(to.Telegram.LanguageCode, "sendReceivedMessage"), fromUserStrMd, utils.CommaInt(int64(amount))))
+	bot.trySendMessage(fromUser.Telegram, fmt.Sprintf(i18n.Translate(fromUser.Telegram.LanguageCode, "sendSentMessage"), utils.CommaInt(int64(amount)), toUserStrMd))
 	if err != nil {
 		errmsg := fmt.Errorf("[sendInline] Error: Send message to %s: %s", toUserStr, err)
 		log.Warnln(errmsg)

--- a/internal/telegram/invoice.go
+++ b/internal/telegram/invoice.go
@@ -10,8 +10,8 @@ import (
 	"github.com/LightningTipBot/LightningTipBot/internal/telegram/intercept"
 	"github.com/nbd-wtf/go-nostr"
 
-       "github.com/LightningTipBot/LightningTipBot/internal/errors"
-       "github.com/LightningTipBot/LightningTipBot/internal/storage"
+	"github.com/LightningTipBot/LightningTipBot/internal/errors"
+	"github.com/LightningTipBot/LightningTipBot/internal/storage"
 
 	"github.com/LightningTipBot/LightningTipBot/internal"
 
@@ -20,10 +20,10 @@ import (
 	"github.com/LightningTipBot/LightningTipBot/internal/i18n"
 	"github.com/LightningTipBot/LightningTipBot/internal/lnbits"
 	"github.com/LightningTipBot/LightningTipBot/internal/runtime"
-       "github.com/LightningTipBot/LightningTipBot/internal/str"
-       "github.com/skip2/go-qrcode"
-       "github.com/LightningTipBot/LightningTipBot/internal/utils"
-       tb "gopkg.in/lightningtipbot/telebot.v3"
+	"github.com/LightningTipBot/LightningTipBot/internal/str"
+	"github.com/LightningTipBot/LightningTipBot/internal/utils"
+	"github.com/skip2/go-qrcode"
+	tb "gopkg.in/lightningtipbot/telebot.v3"
 )
 
 type InvoiceEventCallback map[int]EventHandler
@@ -222,17 +222,17 @@ func (bot *TipBot) notifyInvoiceReceivedEvent(event Event) {
 	}
 
 	if invoiceEvent.UserCurrency == "" || strings.ToLower(invoiceEvent.UserCurrency) == "btc" {
-		bot.trySendMessage(invoiceEvent.User.Telegram, fmt.Sprintf(i18n.Translate(invoiceEvent.User.Telegram.LanguageCode, "invoiceReceivedMessage"), invoiceEvent.Amount))
+		bot.trySendMessage(invoiceEvent.User.Telegram, fmt.Sprintf(i18n.Translate(invoiceEvent.User.Telegram.LanguageCode, "invoiceReceivedMessage"), utils.CommaInt(int64(invoiceEvent.Amount))))
 	} else {
-               fiatAmount, err := SatoshisToFiat(invoiceEvent.Amount, strings.ToUpper(invoiceEvent.UserCurrency))
-               if err != nil {
-                        log.Errorln(err)
-                        // fallback to satoshis
-                        bot.trySendMessage(invoiceEvent.User.Telegram, fmt.Sprintf(i18n.Translate(invoiceEvent.User.Telegram.LanguageCode, "invoiceReceivedMessage"), invoiceEvent.Amount))
-                        return
-               }
-               bot.trySendMessage(invoiceEvent.User.Telegram, fmt.Sprintf(i18n.Translate(invoiceEvent.User.Telegram.LanguageCode, "invoiceReceivedCurrencyMessage"), invoiceEvent.Amount, utils.FormatFloatWithCommas(fiatAmount), strings.ToUpper(invoiceEvent.UserCurrency)))
-       }
+		fiatAmount, err := SatoshisToFiat(invoiceEvent.Amount, strings.ToUpper(invoiceEvent.UserCurrency))
+		if err != nil {
+			log.Errorln(err)
+			// fallback to satoshis
+			bot.trySendMessage(invoiceEvent.User.Telegram, fmt.Sprintf(i18n.Translate(invoiceEvent.User.Telegram.LanguageCode, "invoiceReceivedMessage"), utils.CommaInt(int64(invoiceEvent.Amount))))
+			return
+		}
+		bot.trySendMessage(invoiceEvent.User.Telegram, fmt.Sprintf(i18n.Translate(invoiceEvent.User.Telegram.LanguageCode, "invoiceReceivedCurrencyMessage"), utils.CommaInt(int64(invoiceEvent.Amount)), utils.FormatFloatWithCommas(fiatAmount), strings.ToUpper(invoiceEvent.UserCurrency)))
+	}
 }
 
 type LNURLInvoice struct {

--- a/internal/telegram/lnurl-withdraw.go
+++ b/internal/telegram/lnurl-withdraw.go
@@ -19,6 +19,7 @@ import (
 	"github.com/LightningTipBot/LightningTipBot/internal/i18n"
 	"github.com/LightningTipBot/LightningTipBot/internal/lnbits"
 	"github.com/LightningTipBot/LightningTipBot/internal/runtime"
+	"github.com/LightningTipBot/LightningTipBot/internal/utils"
 
 	"github.com/LightningTipBot/LightningTipBot/internal/str"
 	lnurl "github.com/fiatjaf/go-lnurl"
@@ -180,7 +181,7 @@ func (bot *TipBot) lnurlWithdrawHandlerWithdraw(ctx intercept.Context) (intercep
 		return ctx, fmt.Errorf("invalid type")
 	}
 
-	confirmText := fmt.Sprintf(Translate(ctx, "confirmLnurlWithdrawMessage"), lnurlWithdrawState.Amount/1000)
+	confirmText := fmt.Sprintf(Translate(ctx, "confirmLnurlWithdrawMessage"), utils.CommaInt(int64(lnurlWithdrawState.Amount/1000)))
 	if len(lnurlWithdrawState.LNURLWithdrawResponse.DefaultDescription) > 0 {
 		confirmText = confirmText + fmt.Sprintf(Translate(ctx, "confirmPayAppendMemo"), str.MarkdownEscape(lnurlWithdrawState.LNURLWithdrawResponse.DefaultDescription))
 	}

--- a/internal/telegram/pay.go
+++ b/internal/telegram/pay.go
@@ -15,6 +15,7 @@ import (
 	"github.com/LightningTipBot/LightningTipBot/internal/i18n"
 	"github.com/LightningTipBot/LightningTipBot/internal/lnbits"
 	"github.com/LightningTipBot/LightningTipBot/internal/runtime"
+	"github.com/LightningTipBot/LightningTipBot/internal/utils"
 
 	"github.com/LightningTipBot/LightningTipBot/internal/str"
 	lnurl "github.com/fiatjaf/go-lnurl"
@@ -114,7 +115,7 @@ func (bot *TipBot) payHandler(ctx intercept.Context) (intercept.Context, error) 
 		bot.trySendMessage(ctx.Sender(), Translate(ctx, "feeReserveMessage"))
 	}
 
-	confirmText := fmt.Sprintf(Translate(ctx, "confirmPayInvoiceMessage"), amount)
+	confirmText := fmt.Sprintf(Translate(ctx, "confirmPayInvoiceMessage"), utils.CommaInt(int64(amount)))
 	if len(bolt11.Description) > 0 {
 		confirmText = confirmText + fmt.Sprintf(Translate(ctx, "confirmPayAppendMemo"), str.MarkdownEscape(bolt11.Description))
 	}

--- a/internal/telegram/send.go
+++ b/internal/telegram/send.go
@@ -17,6 +17,7 @@ import (
 	"github.com/LightningTipBot/LightningTipBot/internal/i18n"
 	"github.com/LightningTipBot/LightningTipBot/internal/lnbits"
 	"github.com/LightningTipBot/LightningTipBot/internal/runtime"
+	"github.com/LightningTipBot/LightningTipBot/internal/utils"
 
 	"github.com/LightningTipBot/LightningTipBot/internal/str"
 	"github.com/LightningTipBot/LightningTipBot/pkg/lightning"
@@ -183,7 +184,7 @@ func (bot *TipBot) sendHandler(ctx intercept.Context) (intercept.Context, error)
 	}
 
 	// entire text of the inline object
-	confirmText := fmt.Sprintf(Translate(ctx, "confirmSendMessage"), str.MarkdownEscape(toUserStrMention), amount)
+	confirmText := fmt.Sprintf(Translate(ctx, "confirmSendMessage"), str.MarkdownEscape(toUserStrMention), utils.CommaInt(int64(amount)))
 	if len(sendMemo) > 0 {
 		confirmText = confirmText + fmt.Sprintf(Translate(ctx, "confirmSendAppendMemo"), str.MarkdownEscape(sendMemo))
 	}
@@ -342,18 +343,18 @@ func (bot *TipBot) confirmSendHandler(ctx intercept.Context) (intercept.Context,
 	log.Infof("[💸 send] Send from %s to %s (%d sat).", fromUserStr, toUserStr, amount)
 
 	// notify to user
-	bot.trySendMessage(to.Telegram, fmt.Sprintf(i18n.Translate(to.Telegram.LanguageCode, "sendReceivedMessage"), fromUserStrMd, amount))
+	bot.trySendMessage(to.Telegram, fmt.Sprintf(i18n.Translate(to.Telegram.LanguageCode, "sendReceivedMessage"), fromUserStrMd, utils.CommaInt(int64(amount))))
 	// bot.trySendMessage(from.Telegram, fmt.Sprintf(Translate(ctx, "sendSentMessage"), amount, toUserStrMd))
 	if ctx.Callback().Message.Private() {
 		// if the command was invoked in private chat
 		// the edit below was cool, but we need to get rid of the replymarkup inline keyboard thingy for the main menu to pop up
 		// bot.tryEditMessage(c.Message, fmt.Sprintf(i18n.Translate(sendData.LanguageCode, "sendSentMessage"), amount, toUserStrMd), &tb.ReplyMarkup{})
 		bot.tryDeleteMessage(ctx.Callback().Message)
-		bot.trySendMessage(ctx.Callback().Sender, fmt.Sprintf(i18n.Translate(sendData.LanguageCode, "sendSentMessage"), amount, toUserStrMd))
+		bot.trySendMessage(ctx.Callback().Sender, fmt.Sprintf(i18n.Translate(sendData.LanguageCode, "sendSentMessage"), utils.CommaInt(int64(amount)), toUserStrMd))
 	} else {
 		// if the command was invoked in group chat
-		bot.trySendMessage(ctx.Callback().Sender, fmt.Sprintf(i18n.Translate(from.Telegram.LanguageCode, "sendSentMessage"), amount, toUserStrMd))
-		bot.tryEditMessage(ctx.Callback().Message, fmt.Sprintf(i18n.Translate(sendData.LanguageCode, "sendPublicSentMessage"), amount, fromUserStrMd, toUserStrMd), &tb.ReplyMarkup{})
+		bot.trySendMessage(ctx.Callback().Sender, fmt.Sprintf(i18n.Translate(from.Telegram.LanguageCode, "sendSentMessage"), utils.CommaInt(int64(amount)), toUserStrMd))
+		bot.tryEditMessage(ctx.Callback().Message, fmt.Sprintf(i18n.Translate(sendData.LanguageCode, "sendPublicSentMessage"), utils.CommaInt(int64(amount)), fromUserStrMd, toUserStrMd), &tb.ReplyMarkup{})
 	}
 	// send memo if it was present
 	if len(sendMemo) > 0 {

--- a/internal/telegram/shop_helpers.go
+++ b/internal/telegram/shop_helpers.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/LightningTipBot/LightningTipBot/internal/utils"
+
 	"github.com/LightningTipBot/LightningTipBot/internal/lnbits"
 	"github.com/LightningTipBot/LightningTipBot/internal/runtime"
 	"github.com/LightningTipBot/LightningTipBot/internal/runtime/mutex"
@@ -85,7 +87,7 @@ func (bot TipBot) shopItemSettingsMenu(ctx intercept.Context, shop *Shop, item *
 
 // shopItemConfirmBuyMenu builds the buttons to confirm a purchase
 func (bot TipBot) shopItemConfirmBuyMenu(ctx intercept.Context, shop *Shop, item *ShopItem) *tb.ReplyMarkup {
-	shopItemBuyButton = shopKeyboard.Data(fmt.Sprintf("💸 Pay %d sat", item.Price), "shop_itembuy", item.ID)
+	shopItemBuyButton = shopKeyboard.Data(fmt.Sprintf("💸 Pay %d sat", utils.CommaInt(int64(item.Price))), "shop_itembuy", item.ID)
 	shopItemCancelBuyButton = shopKeyboard.Data("⬅️ Back", "shop_itemcancelbuy", item.ID)
 	buttons := []tb.Row{}
 	buttons = append(buttons, shopKeyboard.Row(shopItemBuyButton))
@@ -111,7 +113,7 @@ func (bot TipBot) shopMenu(ctx intercept.Context, shop *Shop, item *ShopItem) *t
 	shopPrevitemButton = shopKeyboard.Data("<", "shop_previtem", shop.ID)
 	buyButtonText := "📩 Get"
 	if item.Price > 0 {
-		buyButtonText = fmt.Sprintf("Buy (%d sat)", item.Price)
+		buyButtonText = fmt.Sprintf("Buy (%d sat)", utils.CommaInt(int64(item.Price)))
 	}
 	shopBuyitemButton = shopKeyboard.Data(buyButtonText, "shop_buyitem", item.ID)
 

--- a/internal/telegram/ticket.go
+++ b/internal/telegram/ticket.go
@@ -13,6 +13,7 @@ import (
 	"github.com/LightningTipBot/LightningTipBot/internal/runtime"
 	"github.com/LightningTipBot/LightningTipBot/internal/storage"
 	"github.com/LightningTipBot/LightningTipBot/internal/telegram/intercept"
+	"github.com/LightningTipBot/LightningTipBot/internal/utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/skip2/go-qrcode"
 	"github.com/tidwall/buntdb"
@@ -86,7 +87,7 @@ func (bot *TipBot) handleTelegramNewMember(ctx intercept.Context) (intercept.Con
 		Group: group,
 		Base:  storage.New(storage.ID(fmt.Sprintf("ticket-event:%s", id))),
 	}
-	captionText := fmt.Sprintf("⚠️ %s, this group requires you to pay *%d sat* to join. You have 15 minutes to pay or you will be kicked for one day.", GetUserStrMd(ctx.Message().Sender), ticket.Ticket.Price)
+	captionText := fmt.Sprintf("⚠️ %s, this group requires you to pay *%d sat* to join. You have 15 minutes to pay or you will be kicked for one day.", GetUserStrMd(ctx.Message().Sender), utils.CommaInt(int64(ticket.Ticket.Price)))
 
 	var balance int64 = 0
 	if user.ID != "" {

--- a/internal/telegram/tip.go
+++ b/internal/telegram/tip.go
@@ -12,6 +12,8 @@ import (
 	"github.com/LightningTipBot/LightningTipBot/internal"
 	"github.com/LightningTipBot/LightningTipBot/internal/str"
 
+	"github.com/LightningTipBot/LightningTipBot/internal/utils"
+
 	"github.com/LightningTipBot/LightningTipBot/internal/i18n"
 	log "github.com/sirupsen/logrus"
 	tb "gopkg.in/lightningtipbot/telebot.v3"
@@ -131,13 +133,13 @@ func (bot *TipBot) tipHandler(ctx intercept.Context) (intercept.Context, error) 
 	log.Infof("[💸 tip] Tip from %s to %s (%d sat).", fromUserStr, toUserStr, amount)
 
 	// notify users
-	bot.trySendMessage(from.Telegram, fmt.Sprintf(i18n.Translate(from.Telegram.LanguageCode, "tipSentMessage"), amount, toUserStrMd))
+	bot.trySendMessage(from.Telegram, fmt.Sprintf(i18n.Translate(from.Telegram.LanguageCode, "tipSentMessage"), utils.CommaInt(int64(amount)), toUserStrMd))
 
 	// forward tipped message to user once
 	if !messageHasTip {
 		bot.tryForwardMessage(to.Telegram, m.ReplyTo, tb.Silent)
 	}
-	bot.trySendMessage(to.Telegram, fmt.Sprintf(i18n.Translate(to.Telegram.LanguageCode, "tipReceivedMessage"), fromUserStrMd, amount))
+	bot.trySendMessage(to.Telegram, fmt.Sprintf(i18n.Translate(to.Telegram.LanguageCode, "tipReceivedMessage"), fromUserStrMd, utils.CommaInt(int64(amount))))
 
 	if len(tipMemo) > 0 {
 		bot.trySendMessage(to.Telegram, fmt.Sprintf("✉️ %s", str.MarkdownEscape(tipMemo)))

--- a/internal/utils/comma_int.go
+++ b/internal/utils/comma_int.go
@@ -1,0 +1,17 @@
+package utils
+
+import (
+	"fmt"
+	"io"
+)
+
+type CommaInt int64
+
+func (c CommaInt) Format(f fmt.State, verb rune) {
+	switch verb {
+	case 'd', 'v':
+		io.WriteString(f, FormatIntWithCommas(int64(c)))
+	default:
+		fmt.Fprintf(f, "%%!%c(%d)", verb, int64(c))
+	}
+}

--- a/internal/utils/number_format.go
+++ b/internal/utils/number_format.go
@@ -2,30 +2,47 @@ package utils
 
 import "fmt"
 import "strings"
+import "strconv"
 
 // FormatFloatWithCommas formats a float64 with thousands separators and two decimal digits.
 func FormatFloatWithCommas(value float64) string {
-    negative := value < 0
-    if negative {
-        value = -value
-    }
-    s := fmt.Sprintf("%.2f", value)
-    parts := strings.SplitN(s, ".", 2)
-    intPart := parts[0]
-    fracPart := ""
-    if len(parts) > 1 {
-        fracPart = parts[1]
-    }
-    n := len(intPart)
-    for i := n - 3; i > 0; i -= 3 {
-        intPart = intPart[:i] + "," + intPart[i:]
-    }
-    if negative {
-        intPart = "-" + intPart
-    }
-    if fracPart != "" {
-        return intPart + "." + fracPart
-    }
-    return intPart
+	negative := value < 0
+	if negative {
+		value = -value
+	}
+	s := fmt.Sprintf("%.2f", value)
+	parts := strings.SplitN(s, ".", 2)
+	intPart := parts[0]
+	fracPart := ""
+	if len(parts) > 1 {
+		fracPart = parts[1]
+	}
+	n := len(intPart)
+	for i := n - 3; i > 0; i -= 3 {
+		intPart = intPart[:i] + "," + intPart[i:]
+	}
+	if negative {
+		intPart = "-" + intPart
+	}
+	if fracPart != "" {
+		return intPart + "." + fracPart
+	}
+	return intPart
 }
 
+// FormatIntWithCommas formats an int64 with thousands separators.
+func FormatIntWithCommas(value int64) string {
+	negative := value < 0
+	if negative {
+		value = -value
+	}
+	s := strconv.FormatInt(value, 10)
+	n := len(s)
+	for i := n - 3; i > 0; i -= 3 {
+		s = s[:i] + "," + s[i:]
+	}
+	if negative {
+		s = "-" + s
+	}
+	return s
+}


### PR DESCRIPTION
## Summary
- add helper to format integers with commas
- use comma formatting for sats in user messages and keyboard buttons
- keep LKR values formatted with commas too

## Testing
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685f745e1930832c98838455442802e4