### PR TITLE
feat: integrate DCA bot with configuration and deposit notification

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -43,6 +43,11 @@ nostr:
 third_party:
   coinmarketcap_api_key: "your-cmc-api-key-here"  # optional — get free key at coinmarketcap.com/api
 
+# DCA bot integration
+dca:
+  wallet_username: ""  # when sats are received by this Telegram username, reset DCA retry counts
+  api_url: "https://bitcoindeepa-dca-be-production.up.railway.app"
+
 # API Configuration
 api:
   # Analytics API - HMAC authenticated endpoints for data export

--- a/internal/config.go
+++ b/internal/config.go
@@ -19,7 +19,13 @@ var Configuration = struct {
 	Nostr      NostrConfiguration      `yaml:"nostr"`
 	API        APIConfiguration        `yaml:"api"`
 	ThirdParty ThirdPartyConfiguration `yaml:"third_party"`
+	DCA        DCAConfiguration        `yaml:"dca"`
 }{}
+
+type DCAConfiguration struct {
+	WalletUsername string `yaml:"wallet_username"`
+	ApiUrl         string `yaml:"api_url"`
+}
 
 type NostrConfiguration struct {
 	PrivateKey string `yaml:"private_key"`

--- a/internal/dca/dca.go
+++ b/internal/dca/dca.go
@@ -2,6 +2,7 @@ package dca
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/LightningTipBot/LightningTipBot/internal"
@@ -11,7 +12,8 @@ import (
 // NotifyDeposit checks whether the given recipient username matches the configured
 // DCA wallet username and, if so, asks the DCA backend to reset its retry counts.
 func NotifyDeposit(toUsername string) {
-	if internal.Configuration.DCA.WalletUsername == "" || toUsername != internal.Configuration.DCA.WalletUsername {
+	wallet := strings.TrimPrefix(internal.Configuration.DCA.WalletUsername, "@")
+	if wallet == "" || strings.TrimPrefix(toUsername, "@") != wallet {
 		return
 	}
 

--- a/internal/dca/dca.go
+++ b/internal/dca/dca.go
@@ -1,0 +1,34 @@
+package dca
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/LightningTipBot/LightningTipBot/internal"
+	log "github.com/sirupsen/logrus"
+)
+
+// NotifyDeposit checks whether the given recipient username matches the configured
+// DCA wallet username and, if so, asks the DCA backend to reset its retry counts.
+func NotifyDeposit(toUsername string) {
+	if internal.Configuration.DCA.WalletUsername == "" || toUsername != internal.Configuration.DCA.WalletUsername {
+		return
+	}
+
+	url := internal.Configuration.DCA.ApiUrl + "/transaction/reset-retry-counts"
+	req, err := http.NewRequest(http.MethodPost, url, nil)
+	if err != nil {
+		log.Errorf("[DCA] Error creating reset-retry-counts request: %s", err.Error())
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Errorf("[DCA] Error calling reset-retry-counts: %s", err.Error())
+		return
+	}
+	defer resp.Body.Close()
+	log.Infof("[DCA] reset-retry-counts called for %s, status: %s", toUsername, resp.Status)
+}

--- a/internal/dca/dca.go
+++ b/internal/dca/dca.go
@@ -17,7 +17,13 @@ func NotifyDeposit(toUsername string) {
 		return
 	}
 
-	url := internal.Configuration.DCA.ApiUrl + "/transaction/reset-retry-counts"
+	apiUrl := strings.TrimSuffix(internal.Configuration.DCA.ApiUrl, "/")
+	if apiUrl == "" {
+		log.Errorln("[DCA] dca.api_url is not configured, skipping reset-retry-counts call")
+		return
+	}
+
+	url := apiUrl + "/transaction/reset-retry-counts"
 	req, err := http.NewRequest(http.MethodPost, url, nil)
 	if err != nil {
 		log.Errorf("[DCA] Error creating reset-retry-counts request: %s", err.Error())

--- a/internal/lnbits/webhook/webhook.go
+++ b/internal/lnbits/webhook/webhook.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/LightningTipBot/LightningTipBot/internal"
+	"github.com/LightningTipBot/LightningTipBot/internal/dca"
 	"github.com/LightningTipBot/LightningTipBot/internal/lnbits"
 	"github.com/LightningTipBot/LightningTipBot/internal/telegram"
 	"github.com/LightningTipBot/LightningTipBot/internal/utils"
@@ -99,6 +100,8 @@ func (w *Server) receive(writer http.ResponseWriter, request *http.Request) {
 		return
 	}
 	log.Infoln(fmt.Sprintf("[⚡️ WebHook] User %s (%d) received invoice of %d sat.", telegram.GetUserStr(user.Telegram), user.Telegram.ID, webhookEvent.Amount/1000))
+
+	go dca.NotifyDeposit(telegram.GetUserStr(user.Telegram))
 
 	writer.WriteHeader(200)
 

--- a/internal/telegram/transaction.go
+++ b/internal/telegram/transaction.go
@@ -6,6 +6,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/LightningTipBot/LightningTipBot/internal/dca"
 	"github.com/LightningTipBot/LightningTipBot/internal/lnbits"
 	tb "gopkg.in/lightningtipbot/telebot.v3"
 )
@@ -73,6 +74,7 @@ func (t *Transaction) Send() (success bool, err error) {
 	success, err = t.SendTransaction(t.Bot, t.From, t.To, t.Amount, t.Memo)
 	if success {
 		t.Success = success
+		go dca.NotifyDeposit(t.ToUser)
 	}
 
 	// save transaction to db


### PR DESCRIPTION
Add DCA backend integration for retry-count reset on deposits

  Summary

  - Adds new dca config section (wallet_username, api_url) for integrating with the BitcoinDeepa DCA backend.
  - Introduces internal/dca package with NotifyDeposit(toUsername), which calls POST {api_url}/transaction/reset-retry-counts whenever
  sats are deposited into the configured DCA wallet account.
  - Wires NotifyDeposit into both deposit paths:
    - internal/lnbits/webhook/webhook.go — fires for external incoming Lightning payments.
    - internal/telegram/transaction.go — fires for successful internal sends/tips.

  Why

  The DCA bot needs to know when its wallet receives new funds so it can reset its retry counters and resume scheduled purchases.

  Config

  dca:
    wallet_username: ""  # Telegram username of the DCA wallet account
    api_url: "https://bitcoindeepa-dca-be-production.up.railway.app"

  Test plan

  - [ ] Set dca.wallet_username to the DCA account's username and confirm an external deposit (LNbits webhook) triggers the
  reset-retry-counts call (check logs for [DCA] reset-retry-counts called for ...).
  - [ ] Confirm an internal tip/send to the DCA account triggers the same call.
  - [ ] Confirm deposits to other accounts do NOT trigger the call.
  - [ ] Confirm behavior is a no-op when dca.wallet_username is unset.